### PR TITLE
chore(deps): pin `replace-in-file` below v8

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -56,6 +56,11 @@
       // group these two, as they may rely on one another during major version bumps
       matchPackageNames: ['actions/download-artifact', 'actions/upload-artifact'],
       groupName: 'Download + Upload Artifacts',
+    },
+    // v8 converts to ESM, which this package does not support
+    {
+      matchPackageNames: ['replace-in-file'],
+      allowedVersions: '<8.0.0'
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Pins the allowed version of `replace-in-file` in the renovate config below v8. In v8, the package updates to use ESM, which this package cannot use at this time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
